### PR TITLE
Refactor message ordering and update API documentation

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -179,12 +179,6 @@ const docTemplate = `{
                         "description": "Límite de mensajes a obtener",
                         "name": "limit",
                         "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Timestamp para obtener mensajes anteriores",
-                        "name": "before",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -567,12 +561,6 @@ const docTemplate = `{
                         "default": 50,
                         "description": "Límite de mensajes a obtener",
                         "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Timestamp para obtener mensajes anteriores",
-                        "name": "before",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -172,12 +172,6 @@
                         "description": "Límite de mensajes a obtener",
                         "name": "limit",
                         "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Timestamp para obtener mensajes anteriores",
-                        "name": "before",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -560,12 +554,6 @@
                         "default": 50,
                         "description": "Límite de mensajes a obtener",
                         "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Timestamp para obtener mensajes anteriores",
-                        "name": "before",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -192,10 +192,6 @@ paths:
         in: query
         name: limit
         type: integer
-      - description: Timestamp para obtener mensajes anteriores
-        in: query
-        name: before
-        type: string
       produces:
       - application/json
       responses:
@@ -441,10 +437,6 @@ paths:
         in: query
         name: limit
         type: integer
-      - description: Timestamp para obtener mensajes anteriores
-        in: query
-        name: before
-        type: string
       produces:
       - application/json
       responses:

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -129,7 +129,6 @@ func (h *ChatHandler) GetUserRooms(w http.ResponseWriter, r *http.Request) {
 //	@Security		BearerAuth
 //	@Param			roomId	path		string			true	"ID de la sala"
 //	@Param			limit	query		int				false	"Límite de mensajes a obtener"	default(50)
-//	@Param			before	query		string			false	"Timestamp para obtener mensajes anteriores"
 //	@Success		200		{array}		models.Message	"Lista de mensajes de la sala"
 //	@Failure		401		{string}	string			"No autorizado"
 //	@Failure		404		{string}	string			"Sala no encontrada"
@@ -235,7 +234,6 @@ func (h *ChatHandler) GetUserDirectChats(w http.ResponseWriter, r *http.Request)
 //	@Security		BearerAuth
 //	@Param			chatId	path		string			true	"ID del chat directo"
 //	@Param			limit	query		int				false	"Límite de mensajes a obtener"	default(50)
-//	@Param			before	query		string			false	"Timestamp para obtener mensajes anteriores"
 //	@Success		200		{array}		models.Message	"Lista de mensajes del chat directo"
 //	@Failure		401		{string}	string			"No autorizado"
 //	@Failure		404		{string}	string			"Chat no encontrado"

--- a/internal/repositories/message_repository.go
+++ b/internal/repositories/message_repository.go
@@ -63,7 +63,7 @@ func (r *MessageRepository) GetRoomMessages(roomID string, limit int) ([]models.
 	messagesRef := r.FirestoreClient.Client.
 		Collection("rooms").Doc(roomID).
 		Collection("messages").
-		OrderBy("createdAt", firestore.Desc).
+		OrderBy("createdAt", firestore.Asc).
 		Limit(limit)
 
 	docs, err := messagesRef.Documents(ctx).GetAll()
@@ -91,7 +91,7 @@ func (r *MessageRepository) GetDirectChatMessages(directChatID string, limit int
 	messagesRef := r.FirestoreClient.Client.
 		Collection("directChats").Doc(directChatID).
 		Collection("messages").
-		OrderBy("createdAt", firestore.Desc).
+		OrderBy("createdAt", firestore.Asc).
 		Limit(limit)
 
 	docs, err := messagesRef.Documents(ctx).GetAll()


### PR DESCRIPTION
Revise message ordering in chat repositories to ascending and remove deprecated 'before' query parameter from API documentation.