### PR TITLE
Add endpoint to retrieve direct chat details by ID

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -147,6 +147,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/chat/direct/{chatId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Devuelve los detalles de un chat directo específico",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Obtiene un chat directo por ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID del chat directo",
+                        "name": "chatId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Detalles del chat directo",
+                        "schema": {
+                            "$ref": "#/definitions/models.DirectChat"
+                        }
+                    },
+                    "401": {
+                        "description": "No autorizado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Chat no encontrado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Error interno del servidor",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/chat/direct/{chatId}/messages": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -140,6 +140,61 @@
                 }
             }
         },
+        "/chat/direct/{chatId}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Devuelve los detalles de un chat directo específico",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Chat"
+                ],
+                "summary": "Obtiene un chat directo por ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID del chat directo",
+                        "name": "chatId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Detalles del chat directo",
+                        "schema": {
+                            "$ref": "#/definitions/models.DirectChat"
+                        }
+                    },
+                    "401": {
+                        "description": "No autorizado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Chat no encontrado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Error interno del servidor",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/chat/direct/{chatId}/messages": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -206,6 +206,41 @@ paths:
       summary: Registra un nuevo usuario
       tags:
       - Auth
+  /chat/direct/{chatId}:
+    get:
+      consumes:
+      - application/json
+      description: Devuelve los detalles de un chat directo específico
+      parameters:
+      - description: ID del chat directo
+        in: path
+        name: chatId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Detalles del chat directo
+          schema:
+            $ref: '#/definitions/models.DirectChat'
+        "401":
+          description: No autorizado
+          schema:
+            type: string
+        "404":
+          description: Chat no encontrado
+          schema:
+            type: string
+        "500":
+          description: Error interno del servidor
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Obtiene un chat directo por ID
+      tags:
+      - Chat
   /chat/direct/{chatId}/messages:
     get:
       consumes:

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -77,6 +77,7 @@ func NewRouter(
 				r.Route("/direct", func(r chi.Router) {
 					r.Post("/{otherUserId}", chatHandler.CreateDirectChat)
 					r.Get("/me", chatHandler.GetUserDirectChats)
+					r.Get("/{chatId}", chatHandler.GetChat)
 					r.Get("/{chatId}/messages", chatHandler.GetDirectChatMessages)
 				})
 			})


### PR DESCRIPTION
Introduce a new API endpoint to fetch direct chat details by ID, including user access validation to ensure authorized retrieval. Update routing to register the new endpoint.