### PR TITLE
Integrate Firestore client for user display names in WebSocket hub

### DIFF
--- a/internal/pkg/websocket/hub.go
+++ b/internal/pkg/websocket/hub.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"github.com/Parchat/backend/internal/config"
 	"github.com/Parchat/backend/internal/repositories"
 )
 
@@ -32,6 +33,9 @@ type Hub struct {
 	messageRepo    *repositories.MessageRepository
 	roomRepo       *repositories.RoomRepository
 	directChatRepo *repositories.DirectChatRepository
+
+	// Firestore client
+	firestoreClient *config.FirestoreClient
 }
 
 // NewHub inicializa un nuevo Hub
@@ -39,6 +43,7 @@ func NewHub(
 	messageRepo *repositories.MessageRepository,
 	roomRepo *repositories.RoomRepository,
 	directChatRepo *repositories.DirectChatRepository,
+	client *config.FirestoreClient,
 ) *Hub {
 	return &Hub{
 		clients:         make(map[*Client]bool),
@@ -49,6 +54,7 @@ func NewHub(
 		messageRepo:     messageRepo,
 		roomRepo:        roomRepo,
 		directChatRepo:  directChatRepo,
+		firestoreClient: client,
 	}
 }
 

--- a/internal/pkg/websocket/websocket.go
+++ b/internal/pkg/websocket/websocket.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"time"
@@ -143,6 +144,16 @@ func (c *Client) ReadPump() {
 				log.Printf("Error updating last message: %v", err)
 			}
 
+			// Obtener el displayName del usuario
+			ctx := context.Background()
+			userDoc, err := c.hub.firestoreClient.Client.Collection("users").Doc(c.userID).Get(ctx)
+			if err == nil {
+				var user models.User
+				if err := userDoc.DataTo(&user); err == nil {
+					chatMsg.DisplayName = user.DisplayName
+				}
+			}
+
 			// Convertir el mensaje de vuelta a JSON para difundir
 			payload, _ := json.Marshal(chatMsg)
 			wsMessage.Payload = payload
@@ -198,6 +209,16 @@ func (c *Client) ReadPump() {
 			err = c.hub.directChatRepo.UpdateLastMessage(chatMsg.RoomID, &chatMsg)
 			if err != nil {
 				log.Printf("Error updating last message in direct chat: %v", err)
+			}
+
+			// Obtener el displayName del usuario
+			ctx := context.Background()
+			userDoc, err := c.hub.firestoreClient.Client.Collection("users").Doc(c.userID).Get(ctx)
+			if err == nil {
+				var user models.User
+				if err := userDoc.DataTo(&user); err == nil {
+					chatMsg.DisplayName = user.DisplayName
+				}
 			}
 
 			// Convertir el mensaje de vuelta a JSON para difundir


### PR DESCRIPTION
- Integrates Firestore client into the WebSocket hub and client logic to retrieve user display names during message processing.
- Enhances functionality by enabling dynamic user data fetching from Firestore, improving message context for chat interactions.