### PR TITLE
Add user display names to DirectChat model

### DIFF
--- a/internal/models/directchat.go
+++ b/internal/models/directchat.go
@@ -4,10 +4,11 @@ import "time"
 
 // DirectChat representa un chat directo entre dos usuarios
 type DirectChat struct {
-	ID          string    `json:"id" firestore:"id"`
-	UserIDs     []string  `json:"userIds" firestore:"userIds"`
-	LastMessage *Message  `json:"lastMessage,omitempty" firestore:"lastMessage,omitempty"`
-	CreatedAt   time.Time `json:"createdAt" firestore:"createdAt"`
-	UpdatedAt   time.Time `json:"updatedAt" firestore:"updatedAt"`
-	IsDeleted   bool      `json:"isDeleted" firestore:"isDeleted"`
+	ID           string    `json:"id" firestore:"id"`
+	UserIDs      []string  `json:"userIds" firestore:"userIds"`
+	DisplayNames []string  `json:"displayNames" firestore:"displayNames,omitempty"`
+	LastMessage  *Message  `json:"lastMessage,omitempty" firestore:"lastMessage,omitempty"`
+	CreatedAt    time.Time `json:"createdAt" firestore:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt" firestore:"updatedAt"`
+	IsDeleted    bool      `json:"isDeleted" firestore:"isDeleted"`
 }


### PR DESCRIPTION
- Enhances the DirectChat model by introducing `DisplayNames`, enabling retrieval of user names alongside IDs.
- Updates repository logic to populate `DisplayNames` by fetching user details from the UserRepository, improving readability and usability of direct chat data.