### PR TITLE
refactor: Comment out success message logic in ReadPump

### DIFF
--- a/internal/pkg/websocket/websocket.go
+++ b/internal/pkg/websocket/websocket.go
@@ -260,13 +260,13 @@ func (c *Client) ReadPump() {
 				c.rooms[roomID] = true
 				log.Printf("User %s joined room %s", c.userID, roomID)
 				// Enviar mensaje de confirmación al usuario
-				successMsg := "Successfully joined room"
-				successPayload, _ := json.Marshal(successMsg)
-				c.send <- WebSocketMessage{
-					Type:      MessageTypeSuccess,
-					Payload:   successPayload,
-					Timestamp: time.Now(),
-				}
+				// successMsg := "Successfully joined room"
+				// successPayload, _ := json.Marshal(successMsg)
+				// c.send <- WebSocketMessage{
+				// 	Type:      MessageTypeSuccess,
+				// 	Payload:   successPayload,
+				// 	Timestamp: time.Now(),
+				// }
 			} else {
 				errMsg := "No permission to join this room"
 				errorPayload, _ := json.Marshal(errMsg)
@@ -290,13 +290,13 @@ func (c *Client) ReadPump() {
 				c.directChat[directChatID] = true
 				log.Printf("User %s joined direct chat %s", c.userID, directChatID)
 				// Enviar mensaje de confirmación al usuario
-				successMsg := "Successfully joined direct chat"
-				successPayload, _ := json.Marshal(successMsg)
-				c.send <- WebSocketMessage{
-					Type:      MessageTypeSuccess,
-					Payload:   successPayload,
-					Timestamp: time.Now(),
-				}
+				// successMsg := "Successfully joined direct chat"
+				// successPayload, _ := json.Marshal(successMsg)
+				// c.send <- WebSocketMessage{
+				// 	Type:      MessageTypeSuccess,
+				// 	Payload:   successPayload,
+				// 	Timestamp: time.Now(),
+				// }
 			} else {
 				errMsg := "Not a member of this direct chat"
 				errorPayload, _ := json.Marshal(errMsg)


### PR DESCRIPTION
This pull request includes changes to comment out confirmation messages sent to users when they successfully join a room or a direct chat in the WebSocket client. These changes appear to simplify the behavior by removing these success notifications.

### WebSocket client changes:

* [`internal/pkg/websocket/websocket.go`](diffhunk://#diff-61f91744e5023a4d126ada3f6cf085d1b42d0bf85afab2a7707ee88dbae084deL263-R269): Commented out the code responsible for sending a success message to users upon joining a room.
* [`internal/pkg/websocket/websocket.go`](diffhunk://#diff-61f91744e5023a4d126ada3f6cf085d1b42d0bf85afab2a7707ee88dbae084deL293-R299): Commented out the code responsible for sending a success message to users upon joining a direct chat.