### PR TITLE
Enhance Chat Display Logic and Enforce Report Restrictions

### DIFF
--- a/internal/repositories/directchat_repository.go
+++ b/internal/repositories/directchat_repository.go
@@ -113,15 +113,34 @@ func (r *DirectChatRepository) GetUserDirectChats(userID string) ([]models.Direc
 		if err := doc.DataTo(&chat); err != nil {
 			return nil, err
 		}
-
 		// Obtener los nombres actualizados de los usuarios
 		chat.DisplayNames = make([]string, len(chat.UserIDs))
-		for i, id := range chat.UserIDs {
-			user, err := r.UserRepo.GetUserByID(ctx, id)
-			if err == nil && user != nil {
-				chat.DisplayNames[i] = user.DisplayName
-			}
+
+		// Como solo hay dos usuarios en un chat directo
+		// Obtenemos el nombre del primer usuario
+		user0, err := r.UserRepo.GetUserByID(ctx, chat.UserIDs[0])
+		if err == nil && user0 != nil {
+			chat.DisplayNames[0] = user0.DisplayName
+		} else {
+			chat.DisplayNames[0] = "Usuario Desconocido"
 		}
+
+		// Obtenemos el nombre del segundo usuario
+		user1, err := r.UserRepo.GetUserByID(ctx, chat.UserIDs[1])
+		if err == nil && user1 != nil {
+			chat.DisplayNames[1] = user1.DisplayName
+		} else {
+			chat.DisplayNames[1] = "Usuario Desconocido"
+		}
+
+		// Si el usuario actual es el primer usuario, intercambiamos tanto los nombres como los IDs
+		if chat.UserIDs[0] == userID {
+			// Intercambiar DisplayNames
+			chat.DisplayNames[0], chat.DisplayNames[1] = chat.DisplayNames[1], chat.DisplayNames[0]
+			// Intercambiar UserIDs
+			chat.UserIDs[0], chat.UserIDs[1] = chat.UserIDs[1], chat.UserIDs[0]
+		}
+		// Ahora tanto en UserIDs como en DisplayNames, el otro usuario está primero y el usuario actual después
 
 		chats = append(chats, chat)
 	}


### PR DESCRIPTION
This pull request introduces updates to the `DirectChatRepository` and `ModerationService` to improve functionality and enforce stricter validation rules. The key changes include refactoring the logic for fetching user display names in direct chats, adding a new dependency to the `ModerationService`, and implementing additional checks for reporting messages.

### Updates to `DirectChatRepository`:

* Refactored the logic for fetching user display names in direct chats to handle exactly two users. This includes retrieving display names for both users, assigning "Usuario Desconocido" if a user is not found, and swapping names and IDs to ensure the current user always appears second.

### Updates to `ModerationService`:

* Added a new dependency, `roomService`, to `ModerationService` to enable room-related operations. [[1]](diffhunk://#diff-2013199e2f7d71a2fcf4c3f9cacc59180a87ff965ea9af7a1c85dd9ffbcd2581R24) [[2]](diffhunk://#diff-2013199e2f7d71a2fcf4c3f9cacc59180a87ff965ea9af7a1c85dd9ffbcd2581R33-R40)
* Enhanced the `ReportMessage` method to include:
  - A check to prevent banned users from reporting messages.
  - A validation to disallow reporting messages from admins or the room owner, with appropriate error handling.