### PR TITLE
Comment out user permission check in ReadPump method

### DIFF
--- a/internal/pkg/websocket/websocket.go
+++ b/internal/pkg/websocket/websocket.go
@@ -256,26 +256,26 @@ func (c *Client) ReadPump() {
 			}
 
 			// Verificar si el usuario tiene permiso para unirse a la sala
-			if c.hub.roomRepo.CanJoinRoomWebSocket(roomID, c.userID) {
-				c.rooms[roomID] = true
-				log.Printf("User %s joined room %s", c.userID, roomID)
-				// Enviar mensaje de confirmación al usuario
-				// successMsg := "Successfully joined room"
-				// successPayload, _ := json.Marshal(successMsg)
-				// c.send <- WebSocketMessage{
-				// 	Type:      MessageTypeSuccess,
-				// 	Payload:   successPayload,
-				// 	Timestamp: time.Now(),
-				// }
-			} else {
-				errMsg := "No permission to join this room"
-				errorPayload, _ := json.Marshal(errMsg)
-				c.send <- WebSocketMessage{
-					Type:      MessageTypeError,
-					Payload:   errorPayload,
-					Timestamp: time.Now(),
-				}
-			}
+			// if c.hub.roomRepo.CanJoinRoomWebSocket(roomID, c.userID) {
+			// 	c.rooms[roomID] = true
+			// 	log.Printf("User %s joined room %s", c.userID, roomID)
+			// 	// Enviar mensaje de confirmación al usuario
+			// 	// successMsg := "Successfully joined room"
+			// 	// successPayload, _ := json.Marshal(successMsg)
+			// 	// c.send <- WebSocketMessage{
+			// 	// 	Type:      MessageTypeSuccess,
+			// 	// 	Payload:   successPayload,
+			// 	// 	Timestamp: time.Now(),
+			// 	// }
+			// } else {
+			// 	errMsg := "No permission to join this room"
+			// 	errorPayload, _ := json.Marshal(errMsg)
+			// 	c.send <- WebSocketMessage{
+			// 		Type:      MessageTypeError,
+			// 		Payload:   errorPayload,
+			// 		Timestamp: time.Now(),
+			// 	}
+			// }
 
 		// Manejar cuando un usuario quiere escuchar un chat directo
 		case MessageTypeJoinDirectChat:


### PR DESCRIPTION
Remove the user permission check in the ReadPump method to simplify the logic for joining rooms. This change allows for further testing and adjustments without the permission constraint.